### PR TITLE
feat: Support IPC(UDS)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,8 +4,14 @@ version = "0.1.0"
 edition = "2021"
 
 [dependencies]
+async-stream = "0.3.5"
 clap = { version = "4.4.6", features = ["derive"] }
-reqwest = { version = "0.11.22", default-features = false, features = ["stream", "blocking", "json"] }
+futures-core = "0.3.29"
+futures-util = "0.3.29"
+hyper = "0.14.27"
+hyperlocal = "0.8.0"
 serde = { version = "1.0.189", features = ["derive"] }
 serde_json = "1.0.107"
+tokio = { version = "1.33.0", features = ["rt", "macros", "io-std", "rt-multi-thread", "sync", "io-util"] }
+tokio-util = { version = "0.7.10", features = ["io"] }
 url = "2.4.1"

--- a/src/main.rs
+++ b/src/main.rs
@@ -36,6 +36,9 @@ enum Commands {
     // Inspect(Inspect),
 }
 
+//use std::error::Error;
+//#[tokio::main]
+//async fn main() -> Result<(), Box<dyn Error + Send + Sync>> {
 fn main() {
     let cli = Cli::parse();
 
@@ -48,7 +51,7 @@ fn main() {
             memory_shared,
             files,
         } => {
-            let cmd=Run::new(RunArgs {
+            let cmd = Run::new(RunArgs {
                 memory_initial: *memory_initial,
                 memory_maximum: *memory_maximum,
                 memory_shared: *memory_shared,
@@ -56,5 +59,5 @@ fn main() {
             });
             cmd.run();
         }
-    }
+    };
 }

--- a/src/ndjson.rs
+++ b/src/ndjson.rs
@@ -32,6 +32,9 @@ pub fn ndjson(response: Response<Body>) -> impl Stream<Item = Value> {
     stream! {
         let br = response_to_buf_reader(response);
         pin_mut!(br);
+        // TODO tokio_util::io::ReaderStream とアダプター利用を検討.
+        //    - Deserializer の結果を async 対応すれば stream! マクロを使わずに済むはず
+        //    - flatmap で複数行をまとめて desirealize することができる、かな?
          loop{
         let mut buf:String=String::new();
             let num_bytes = br.read_line(&mut buf).await.unwrap();

--- a/src/ndjson.rs
+++ b/src/ndjson.rs
@@ -1,0 +1,86 @@
+use hyper::body::HttpBody;
+use hyper::Body;
+use hyper::{body::Bytes, Response};
+use tokio::io::{AsyncBufReadExt, BufReader, Result};
+use tokio_util::io::StreamReader;
+
+use async_stream::stream;
+
+use futures_core::stream::Stream;
+use futures_util::pin_mut;
+
+use serde_json::{Deserializer, Value};
+
+pub fn response_to_stream(response: Response<Body>) -> impl Stream<Item = Result<Bytes>> {
+    stream! {
+        pin_mut!(response);
+        while let Some(chunk) = response.data().await {
+            yield Ok(chunk.unwrap());
+        }
+    }
+}
+
+pub fn response_to_buf_reader(
+    response: Response<Body>,
+) -> BufReader<StreamReader<impl Stream<Item = Result<Bytes>>, Bytes>> {
+    let stream = response_to_stream(response);
+    let rr = StreamReader::new(stream);
+    BufReader::new(rr)
+}
+
+pub fn ndjson(response: Response<Body>) -> impl Stream<Item = Value> {
+    stream! {
+        let br = response_to_buf_reader(response);
+        pin_mut!(br);
+         loop{
+        let mut buf:String=String::new();
+            let num_bytes = br.read_line(&mut buf).await.unwrap();
+            if num_bytes == 0 {
+                break;
+            }
+            let value = Deserializer::from_slice(buf.as_bytes()).into_iter::<Value>();
+            for val in value {
+                yield val.unwrap();
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use futures_util::StreamExt;
+
+    use super::*;
+
+    #[tokio::test]
+    async fn test_response_to_buf_reader() {
+        let br = response_to_buf_reader(Response::new(Body::from(
+            "{\"id\": 1}\n{\"id\": 2}\n{\"id\": 3}",
+        )));
+        pin_mut!(br);
+
+        let mut pool: Vec<String> = Vec::new();
+        let l = tokio::io::Lines::from(br.lines());
+        pin_mut!(l);
+        while let Some(line) = l.next_line().await.unwrap() {
+            pool.push(line);
+        }
+        assert_eq!(pool, vec!["{\"id\": 1}", "{\"id\": 2}", "{\"id\": 3}"]);
+    }
+
+    #[tokio::test]
+    async fn test_ndjson_br() {
+        // 行が分割された状態をテストできていない。
+        // srv.mjs でのテストでは分割した状態で行っている(と思う)。
+        let response = Response::new(Body::from("{\"id\": 1}\n{\"id\": 2}\n{\"id\": 3}"));
+        let stream = ndjson(response);
+        pin_mut!(stream);
+
+        let mut pool: Vec<i64> = Vec::new();
+        while let Some(value) = stream.next().await {
+            pool.push(value["id"].as_i64().unwrap());
+        }
+
+        assert_eq!(pool, vec![1, 2, 3]);
+    }
+}

--- a/test/srv.mjs
+++ b/test/srv.mjs
@@ -28,11 +28,16 @@ const ipcHandlePath = process.env["IPC_HANDLE_PATH"];
 
 const server = http.createServer();
 
-server.once("request", (req, res) => {
+server.once("request", async (req, res) => {
   const r = getRouteAndArgs(req.url);
 
-  res.write(JSON.stringify({ id: 0, data: r.route }));
-  res.end(JSON.stringify({ id: 1, data: r.args }));
+  const s1 = JSON.stringify({ id: 0, data: r.route });
+  await new Promise((resolve) => res.write(s1.slice(0, 3), resolve));
+  await new Promise((resolve) => res.write(s1.slice(3), resolve));
+
+  const s2 = JSON.stringify({ id: 1, data: r.args });
+  await new Promise((resolve) => res.write(s2.slice(0, 3), resolve));
+  res.end(s2.slice(3));
   server.close();
 });
 

--- a/test/srv.mjs
+++ b/test/srv.mjs
@@ -24,6 +24,8 @@ function getRouteAndArgs(url) {
   };
 }
 
+const ipcHandlePath = process.env["IPC_HANDLE_PATH"];
+
 const server = http.createServer();
 
 server.once("request", (req, res) => {
@@ -34,4 +36,4 @@ server.once("request", (req, res) => {
   server.close();
 });
 
-server.listen(3000);
+server.listen(ipcHandlePath || 3000);

--- a/test/test_cli.sh
+++ b/test/test_cli.sh
@@ -7,10 +7,17 @@ trap "rm -rf ${TEMP_DIR}" EXIT
 OUT_FILE="${TEMP_DIR}/out"
 ERR_FILE="${TEMP_DIR}/err"
 
+export IPC_HANDLE_PATH="${TEMP_DIR}/ipc.sock"
 node test/srv.mjs &
-cargo run -q -- run --memory-initial 100 test.wasm \
+
+cargo build -q
+echo "START"
+./target/debug/workspace run --memory-initial 100 test.wasm \
     1> "${OUT_FILE}" \
     2> "${ERR_FILE}"
+
+cat "${OUT_FILE}"
+cat "${ERR_FILE}"
 
 diff <<< '"/run"' "${OUT_FILE}" -
 diff <<< '["--memory_initial","100","--memory_maximum","0","--memory_shared","true","--","test.wasm"]' "${ERR_FILE}" -

--- a/test/test_cli.sh
+++ b/test/test_cli.sh
@@ -8,6 +8,7 @@ OUT_FILE="${TEMP_DIR}/out"
 ERR_FILE="${TEMP_DIR}/err"
 
 export IPC_HANDLE_PATH="${TEMP_DIR}/ipc.sock"
+# TODO: リクエストが実行される前にテストが落ちるとサーバーが稼働したままになる.後処理を検討.
 node test/srv.mjs &
 
 cargo build -q


### PR DESCRIPTION
UDS を使うために `reqwest` から `hyper` + `hyperlocal` をへ変更。
`serde_json::Deserializer::from_reader` が使えなくなるため nsjdon 用に行区切りを意識する処理が必要となる。